### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/Source/TempoDisplay.cpp
+++ b/Source/TempoDisplay.cpp
@@ -50,5 +50,6 @@ double CTempoDisplay::GetAverageBPM() const {
 		BPMtot += bpm * ticks;
 		TickTot += ticks;
 	}
-	return BPMtot / TickTot;
+	if (TickTot != 0) return BPMtot / TickTot;
+	else return 0;
 }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V609](https://www.viva64.com/en/w/v609/) Divide by zero. Denominator 'TickTot' == 0. tempodisplay.cpp 53