### PR TITLE
JSON export now includes note mapping for dpcm key

### DIFF
--- a/Source/Clipboard.h
+++ b/Source/Clipboard.h
@@ -58,6 +58,7 @@ private:
 };
 
 bool CopyToClipboard(CWnd *parent, CLIPFORMAT ClipboardID, const CBinarySerializableInterface &ser);
+bool ReadGlobalMemory(CBinarySerializableInterface& ser, HGLOBAL hMem);
 
 template <typename T>
 std::optional<T> RestoreFromClipboard(CWnd *parent, CLIPFORMAT ClipboardID) {
@@ -77,7 +78,6 @@ std::optional<T> RestoreFromClipboard(CWnd *parent, CLIPFORMAT ClipboardID) {
 	return std::nullopt;
 }
 
-bool ReadGlobalMemory(CBinarySerializableInterface &ser, HGLOBAL hMem);
 DROPEFFECT DragDropTransfer(const CBinarySerializableInterface &ser, CLIPFORMAT clipboardID, DWORD effects);
 
 } // namespace CClipboard

--- a/Source/FamiTrackerDocIOJson.cpp
+++ b/Source/FamiTrackerDocIOJson.cpp
@@ -412,6 +412,7 @@ void to_json(json &j, const CInstrument2A03 &inst) {
 				{"pitch", inst.GetSamplePitch(n) & 0x0Fu},
 				{"loop", inst.GetSampleLoop(n)},
 				{"delta", inst.GetSampleDeltaValue(n)},
+				{"note", n},
 			});
 }
 


### PR DESCRIPTION
Fixes #104

Also resolves an unrelated build issue I was getting. A function was declared in a header, but referenced in a template in that same header before it was used. In Visual Studio 2022, this caused a compile error.